### PR TITLE
Write padded source signal to the disk and rename unpadded signal to original_source

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,9 @@ $(SMS_WSJ_DIR)/observation: $(JSON_DIR)/intermediate_sms_wsj.json | $(SMS_WSJ_DI
 	mpiexec -np ${num_jobs} python -m sms_wsj.database.write_files \
 	with dst_dir=$(SMS_WSJ_DIR) json_path=$(JSON_DIR)/intermediate_sms_wsj.json write_all=$(WRITE_ALL) debug=$(DEBUG)
 
+clean_write_files:
+	rm -rf $(SMS_WSJ_DIR)/{observation,noise,early,tail,speech_source}
+
 sms_wsj.json: $(JSON_DIR)/sms_wsj.json | $(SMS_WSJ_DIR)/observation
 $(JSON_DIR)/sms_wsj.json: $(JSON_DIR)/intermediate_sms_wsj.json | $(SMS_WSJ_DIR)
 	@echo creating $(JSON_DIR)/sms_wsj.json

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Afterwards you can create the database:
 $ make WSJ_DIR=/path/to/wsj SMS_WSJ_DIR=/path/to/write/db/to
 ```
 If desired the number of parallel jobs may be specified using the additonal
-input num_jobs. Per default 16 parallel jobs are used.
+input num_jobs. Per default `nproc --all` parallel jobs are used.
 
 
 The RIRs are downloaded by default, to generate them yourself see [here](#q-i-want-to-generate-the-rirs-myself-how-can-i-do-that).

--- a/sms_wsj/database/create_intermediate_json.py
+++ b/sms_wsj/database/create_intermediate_json.py
@@ -221,25 +221,25 @@ def get_randomized_example(
             return num_samples
 
     example['num_samples'] = dict()
-    example['num_samples']['speech_source'] = [
+    example['num_samples']['original_source'] = [
         _get_num_samples(exa['num_samples']['observation'])
         for exa in source_examples
     ]
     example['num_samples']['observation'] = max(
-        example['num_samples']['speech_source']
+        example['num_samples']['original_source']
     )
 
     example["offset"] = []
     for k in range(example['num_speakers']):
         excess_samples = (
             example['num_samples']['observation']
-            - example['num_samples']['speech_source'][k]
+            - example['num_samples']['original_source'][k]
         )
         assert excess_samples >= 0, excess_samples
         example["offset"].append(rng.randint(0, excess_samples + 1))
 
     example['audio_path'] = dict()
-    example['audio_path']['speech_source'] = [
+    example['audio_path']['original_source'] = [
         exa['audio_path']['observation'] for exa in source_examples
     ]
     example['audio_path']['rir'] = [

--- a/sms_wsj/database/create_json_for_written_files.py
+++ b/sms_wsj/database/create_json_for_written_files.py
@@ -105,7 +105,7 @@ def main(db_dir, intermed_json_path , write_all, json_path, snr_range):
     message = f'Not all wav files seem to exists, you have {num_wav_files},' \
         f' please check your db directory: {db_dir}'
     if write_all:
-        assert num_wav_files == (2 * 2 + 2) * 35875, message
+        assert num_wav_files in [(2 * speakers + 2) * 35875 for speakers in [2, 3, 4]], message
     else:
         assert num_wav_files == 35875, message
     updated_json = create_json(db_dir, intermed_json_path , write_all,

--- a/sms_wsj/database/create_json_for_written_files.py
+++ b/sms_wsj/database/create_json_for_written_files.py
@@ -54,12 +54,6 @@ def create_json(db_dir, intermediate_json_path, write_all, snr_range=(20, 30)):
                 for rir in ex['audio_path']['original_source']
             ]
 
-            ex['audio_path']['rir'] = [
-                # .../sms_wsj/cache/rirs/train_si284/0/h_0.wav
-                str(db_dir.joinpath(*Path(rir).parts[-4:]))
-                for rir in ex['audio_path']['rir']
-            ]
-
             rng = _example_id_to_rng(ex_id)
             snr = rng.uniform(*snr_range)
             if 'dataset' in ex:

--- a/sms_wsj/database/create_json_for_written_files.py
+++ b/sms_wsj/database/create_json_for_written_files.py
@@ -44,10 +44,14 @@ def create_json(db_dir, intermediate_json_path, write_all, snr_range=(20, 30)):
                         for k in range(len(ex['speaker_id']))
                     ]
 
-            ex['audio_path']['speech_source'] = [
+            if 'original_source' not in ex['audio_path']:
+                # legacy code
+                ex['audio_path']['original_source'] = ex['audio_path']['speech_source']
+
+            ex['audio_path']['original_source'] = [
                 # .../sms_wsj/cache/wsj_8k_zeromean/13-11.1/wsj1/si_tr_s/4ax/4axc0218.wav
                 str(db_dir.joinpath(*Path(rir).parts[-6:]))
-                for rir in ex['audio_path']['speech_source']
+                for rir in ex['audio_path']['original_source']
             ]
 
             ex['audio_path']['rir'] = [

--- a/sms_wsj/database/database.py
+++ b/sms_wsj/database/database.py
@@ -112,7 +112,7 @@ class AudioReader:
     """
     def __init__(
             self,
-            keys=[
+            keys=(
                 'observation',
                 'speech_source',
                 'original_source',
@@ -120,8 +120,8 @@ class AudioReader:
                 'speech_reverberation_tail',
                 'speech_image',
                 'noise_image',
-                # 'rir'
-            ],
+                # 'rir',
+            ),
             sync_speech_source: bool = True,  # legacy
     ):
         keys = list(keys)
@@ -145,10 +145,7 @@ class AudioReader:
             self.speech_image = False
 
         self.keys = tuple(keys)
-        if 'speech_source' in keys:
-            self.sync_speech_source = sync_speech_source
-        else:
-            self.sync_speech_source = False
+        self.sync_speech_source = sync_speech_source
 
     @classmethod
     def _rec_audio_read(cls, file):

--- a/sms_wsj/database/database.py
+++ b/sms_wsj/database/database.py
@@ -115,15 +115,25 @@ class AudioReader:
             keys=[
                 'observation',
                 'speech_source',
+                'original_source',
                 'speech_reverberation_early',
                 'speech_reverberation_tail',
                 'speech_image',
                 'noise_image',
                 # 'rir'
             ],
-            sync_speech_source: bool = True,
+            sync_speech_source: bool = True,  # legacy
     ):
         keys = list(keys)
+
+        if 'speech_source' in keys:
+            if 'original_source' not in keys:
+                keys.append('original_source')
+            keys.remove('speech_source')
+            self.speech_source = True
+        else:
+            self.speech_source = False
+
         if 'speech_image' in keys:
             if 'speech_reverberation_early' not in keys:
                 keys.append('speech_reverberation_early')
@@ -159,13 +169,17 @@ class AudioReader:
         for k in self.keys:
             data[k] = self._rec_audio_read(path[k])
 
-        if self.sync_speech_source:
-            from sms_wsj.database.utils import synchronize_speech_source
-            data['speech_source'] = synchronize_speech_source(
-                data['speech_source'],
-                example['offset'],
-                T=example['num_samples']['observation'],
-            )
+        if self.speech_source:
+            if self.sync_speech_source:
+                from sms_wsj.database.utils import synchronize_speech_source
+                data['speech_source'] = synchronize_speech_source(
+                    data['original_source'],
+                    example['offset'],
+                    T=example['num_samples']['observation'],
+                )
+            else:
+                # legacy code
+                data['speech_source'] = data['original_source']
 
         if self.speech_image:
             data['speech_image'] = (

--- a/sms_wsj/database/database.py
+++ b/sms_wsj/database/database.py
@@ -167,6 +167,9 @@ class AudioReader:
         path = example['audio_path']
 
         for k in self.keys:
+            if k == 'original_source' and k not in path:
+                # legacy code
+                path[k] = path['speech_source']
             data[k] = self._rec_audio_read(path[k])
 
         if self.speech_source:

--- a/sms_wsj/database/database.py
+++ b/sms_wsj/database/database.py
@@ -110,6 +110,17 @@ class AudioReader:
      'speech_image': array(shape=(2, 6, 103650), dtype=float64),
      'noise_image': array(shape=(6, 103650), dtype=float64)}
     """
+    all_keys = (
+        'observation',
+        'speech_source',
+        'original_source',
+        'speech_reverberation_early',
+        'speech_reverberation_tail',
+        'speech_image',
+        'noise_image',
+        'rir',
+    )
+
     def __init__(
             self,
             keys=(

--- a/sms_wsj/database/utils.py
+++ b/sms_wsj/database/utils.py
@@ -171,6 +171,9 @@ def scenario_map_fn(
     if 'original_source' not in example['audio_data']:
         # legacy code
         example['audio_data']['original_source'] = example['audio_data']['speech_source']
+    if 'original_source' not in example['num_samples']:
+        # legacy code
+        example['num_samples']['original_source'] = example['num_samples']['speech_source']
     s = example['audio_data']['original_source']
 
     def get_convolved_signals(h):

--- a/sms_wsj/database/utils.py
+++ b/sms_wsj/database/utils.py
@@ -126,6 +126,8 @@ def scenario_map_fn(
         add_speech_reverberation_early=True,
         add_speech_reverberation_tail=True,
 
+        early_rir_samples: int = int(8000 * 0.05),  # 50 milli seconds
+
         details=False,
 ):
     """
@@ -158,7 +160,8 @@ def scenario_map_fn(
     # rir_stop_sample = rir_start_sample + int(SAMPLE_RATE * 0.05)
     # Use 50 milliseconds as early rir part, excluding the propagation delay
     #    (i.e. "rir_start_sample")
-    rir_stop_sample = rir_start_sample + int(8000 * 0.05)
+    assert isinstance(early_rir_samples, int), (type(early_rir_samples), early_rir_samples)
+    rir_stop_sample = rir_start_sample + early_rir_samples
 
     log_weights = example['log_weights']
 

--- a/sms_wsj/database/utils.py
+++ b/sms_wsj/database/utils.py
@@ -92,17 +92,17 @@ def get_white_noise_for_signal(
         return noise_signal
 
 
-def synchronize_speech_source(speech_source, offset, T):
+def synchronize_speech_source(original_source, offset, T):
     """
     >>> from sms_wsj.database.database import SmsWsj, AudioReader
     >>> ds = SmsWsj().get_dataset('cv_dev93')
     >>> example = ds[0]
-    >>> speech_source = AudioReader._rec_audio_read(
-    ...     example['audio_path']['speech_source'])
-    >>> [s.shape for s in speech_source]
+    >>> original_source = AudioReader._rec_audio_read(
+    ...     example['audio_path']['original_source'])
+    >>> [s.shape for s in original_source]
     [(103650,), (93411,)]
     >>> synchronize_speech_source(
-    ...     speech_source,
+    ...     original_source,
     ...     example['offset'],
     ...     T=example['num_samples']['observation'],
     ... ).shape
@@ -111,7 +111,7 @@ def synchronize_speech_source(speech_source, offset, T):
     return np.array([
         extract_piece(x_, offset_, T)
         for x_, offset_ in zip(
-            speech_source,
+            original_source,
             offset,
         )
     ])
@@ -165,15 +165,18 @@ def scenario_map_fn(
     # The two sources have to be cut to same length
     K = example['num_speakers']
     T = example['num_samples']['observation']
-    s = example['audio_data']['speech_source']
+    if 'original_source' not in example['audio_data']:
+        # legacy code
+        example['audio_data']['original_source'] = example['audio_data']['speech_source']
+    s = example['audio_data']['original_source']
 
     def get_convolved_signals(h):
         assert s.shape[0] == h.shape[0], (s.shape, h.shape)
         x = [fftconvolve(s_[..., None, :], h_, axes=-1)
              for s_, h_ in zip(s, h)]
 
-        assert len(x) == len(example['num_samples']['speech_source'])
-        for x_, T_ in zip(x, example['num_samples']['speech_source']):
+        assert len(x) == len(example['num_samples']['original_source'])
+        for x_, T_ in zip(x, example['num_samples']['original_source']):
             assert x_.shape == (D, T_ + rir_length - 1), (
                 x_.shape, D, T_ + rir_length - 1)
 
@@ -231,10 +234,14 @@ def scenario_map_fn(
 
     if sync_speech_source:
         example['audio_data']['speech_source'] = synchronize_speech_source(
-            example['audio_data']['speech_source'],
+            example['audio_data']['original_source'],
             offset=example['offset'],
             T=T,
         )
+    else:
+        # legacy code
+        example['audio_data']['speech_source'] = \
+            example['audio_data']['original_source']
 
     clean_mix = np.sum(x, axis=0)
 


### PR DESCRIPTION
First, thanks to @Emrys365 for reporting, that we don't write the padded source signal to the disk.

In the python code is an option, that the `source_signal` gets padded, when the example is computed on demand.
The padding is a pretty cheap operation and saves disk space:
  - Only the original WSJ utterance must be saved on the disk.
  - Each utterance is used multiple times (e.g. 2 times in the training dataset).
     - So the padded source signal take at least 2 times more disk space as the unpadded signal (Ignoring the required disk space for the padded part).

A problem occurs, when users just want to use the written files and not our proposed python code.

This PR addresses this problem and writes the padded source signal to the disk.
Now we also want to distinguish between the unpadded and the padded source signal.

After an internal discussion, we think the following names for them are reasonable:
 - `original_source`: The unchanged WSJ signal, except for the sample rate, that should match
 - `speech_source`: The signal that is reverberated and used to create the observation. So this is the padded `original_source`.

Since most people are interested in the `speech_source`, this won't be a breaking change for them.
Furthermore, I tried to make the python code to be backward compatiple.