### PR TITLE
scenario_map_fn: bugfix and memory optimization 

### DIFF
--- a/sms_wsj/database/utils.py
+++ b/sms_wsj/database/utils.py
@@ -157,13 +157,22 @@ def scenario_map_fn(
             The speech_image is always computed, but when it is not needed,
             this option can reduce the memory consumption.
         add_speech_reverberation_early:
-            Calculate the speech_reverberation_early signal.
+            Calculate the speech_reverberation_early signal, i.e., the speech
+            source (padded original source) convolved with the early part of
+            the RIR.
         add_speech_reverberation_tail:
-            Calculate the speech_reverberation_tail signal.
+            Calculate the speech_reverberation_tail signal, i.e., the speech
+            source (padded original source) convolved with the tail part of
+            the RIR.
         add_noise_image:
             If True, add the noise_image the returned example.
             This option has no effect to the computation time or the peak
             memory consumption.
+        early_rir_samples:
+            The number of samples that we count as the early RIR, default 50ms.
+            The remaining part of the RIR we call tail.
+            Note: The length of the early RIR is the time of flight plus this
+            value.
         channel_slice: e.g. None (All channels), [4] (Single channel), ...
             Warning: Use this only for training. It will change the scale of
             the data and the added white noise.

--- a/sms_wsj/database/utils.py
+++ b/sms_wsj/database/utils.py
@@ -128,8 +128,11 @@ def scenario_map_fn(
         snr_range: tuple = (20, 30),
 
         sync_speech_source=True,
+
+        add_speech_image=True,
         add_speech_reverberation_early=True,
         add_speech_reverberation_tail=True,
+        add_noise_image=True,
 
         early_rir_samples: int = int(8000 * 0.05),  # 50 milli seconds
         channel_slice: [None, slice, tuple, list] = None,
@@ -150,10 +153,17 @@ def scenario_map_fn(
             padded signal.
             pad and/or cut the source signal to match the length of the
             observations. Considers the offset.
+        add_speech_image:
+            The speech_image is always computed, but when it is not needed,
+            this option can reduce the memory consumption.
         add_speech_reverberation_early:
-            Calculate the add_speech_reverberation_early signal.
+            Calculate the speech_reverberation_early signal.
         add_speech_reverberation_tail:
             Calculate the speech_reverberation_tail signal.
+        add_noise_image:
+            If True, add the noise_image the returned example.
+            This option has no effect to the computation time or the peak
+            memory consumption.
         channel_slice: e.g. None (All channels), [4] (Single channel), ...
             Warning: Use this only for training. It will change the scale of
             the data and the added white noise.
@@ -237,7 +247,11 @@ def scenario_map_fn(
     scale /= 71
 
     x *= scale
-    example['audio_data']['speech_image'] = x
+    if add_speech_image:
+        example['audio_data']['speech_image'] = x
+
+    clean_mix = np.sum(x, axis=0)
+    del x  # Reduce memory consumption for the case of `not add_speech_image`
 
     if add_speech_reverberation_early:
         h_early = h.copy()
@@ -273,8 +287,6 @@ def scenario_map_fn(
         example['audio_data']['speech_source'] = \
             example['audio_data']['original_source']
 
-    clean_mix = np.sum(x, axis=0)
-
     rng = _example_id_to_rng(example['example_id'])
     snr = rng.uniform(*snr_range)
     example["snr"] = snr
@@ -282,8 +294,13 @@ def scenario_map_fn(
     rng = _example_id_to_rng(example['example_id'])
 
     n = get_white_noise_for_signal(clean_mix, snr=snr, rng_state=rng)
-    example['audio_data']['noise_image'] = n
-    example['audio_data']['observation'] = clean_mix + n
+    if add_noise_image:
+        example['audio_data']['noise_image'] = n
+
+    observation = clean_mix
+    observation += n  # Inplace to reduce memory consumption
+    example['audio_data']['observation'] = observation
+
     return example
 
 

--- a/sms_wsj/database/utils.py
+++ b/sms_wsj/database/utils.py
@@ -211,7 +211,7 @@ def scenario_map_fn(
     s = example['audio_data']['original_source']
 
     def get_convolved_signals(h):
-        assert s.shape[0] == h.shape[0], (s.shape, h.shape)
+        assert len(s) == h.shape[0], (len(s), h.shape)
         x = [fftconvolve(s_[..., None, :], h_, axes=-1)
              for s_, h_ in zip(s, h)]
 


### PR DESCRIPTION
 - Usually `original_source` is an `nd.array` with dtype `np.object`. This PR allows also list and tuple.
 - Add `add_speech_image` and `add_noise_image` arguments to reduce memory footprint.
